### PR TITLE
Remove default value for program code, and restore ability to select …

### DIFF
--- a/open_data_federal_extras.features.field_instance.inc
+++ b/open_data_federal_extras.features.field_instance.inc
@@ -115,11 +115,7 @@ function open_data_federal_extras_field_default_field_instances() {
   // Exported field_instance: 'node-dataset-field_odfe_program_code'
   $field_instances['node-dataset-field_odfe_program_code'] = array(
     'bundle' => 'dataset',
-    'default_value' => array(
-      0 => array(
-        'value' => '005-003',
-      ),
-    ),
+    'default_value' => NULL,
     'deleted' => 0,
     'description' => 'Adds Program Code, "Required If-Applicable" field for <a href="http://project-open-data.github.io/schema/#common-core-required-if-applicable-fields">Project Open Data</a>.',
     'display' => array(

--- a/open_data_federal_extras.module
+++ b/open_data_federal_extras.module
@@ -66,7 +66,7 @@ function open_data_federal_extras_form_alter(&$form, $form_state, $form_id) {
         $path = drupal_get_path('module', 'open_data_federal_extras');
         include $path . '/fed_program_code_list/federal_inventory_agencies.php';
         $options = $form['field_odfe_bureau_code']['und']['#options'];
-        $concat_options = array();
+        $concat_options = array('_none' => $options['_none']);
         foreach ($options as $key => $value) {
           $pattern = '/^' . $agency_code . '-[\d]/';
           if (preg_match($pattern, $key)) {


### PR DESCRIPTION
…"none" for bureau code

This is in response to NuCivic/usda-nal#390
