### PR TITLE
Fixed bureau code and program code select lists on add dataset from.

### DIFF
--- a/open_data_federal_extras.module
+++ b/open_data_federal_extras.module
@@ -74,7 +74,7 @@ function open_data_federal_extras_form_alter(&$form, $form_state, $form_id) {
         $options = $form['field_odfe_bureau_code']['und']['#options'];
         $concat_options = array('_none' => $options['_none']);
         foreach ($options as $key => $value) {
-          $pattern = '/^' . $agency_code . '-[\d]/';
+          $pattern = '/^' . $agency_code . '\:[\d]/';
           if (preg_match($pattern, $key)) {
             $agency_name = $federal_inventory_agency_list[$agency_code];
             $value = str_replace($agency_name . ' - ', ' ', $value);
@@ -86,7 +86,7 @@ function open_data_federal_extras_form_alter(&$form, $form_state, $form_id) {
         $options = $form['field_odfe_program_code']['und']['#options'];
         $concat_options = array();
         foreach ($options as $key => $value) {
-          $pattern = '/^' . $agency_code . '-[\d]/';
+          $pattern = '/^' . $agency_code . '\:[\d]/';
           if (preg_match($pattern, $key)) {
             $agency_name = $federal_inventory_agency_list[$agency_code];
             $value = str_replace($agency_name . ' - ', ' ', $value);


### PR DESCRIPTION
ref https://github.com/NuCivic/usda-nal/issues/770
Dkan issue: https://github.com/NuCivic/dkan/issues/901

In USDA the Bureau code and program code options failed to appear in the select boxes.
### Acceptance
- [ ] Options for bureau and program code should be available in each select list.
