### PR TITLE
fix: Add missing features_override dependency

### DIFF
--- a/open_data_federal_extras.info
+++ b/open_data_federal_extras.info
@@ -8,6 +8,7 @@ dependencies[] = autocomplete_deluxe
 dependencies[] = ctools
 dependencies[] = dkan_dataset_content_types
 dependencies[] = features
+dependencies[] = features_override
 dependencies[] = field_group
 dependencies[] = link
 dependencies[] = list


### PR DESCRIPTION
### Description

Installing this module on a OOB Dkan install will not add the odf fields to the datasets unless the features_override module is installed.
