### PR TITLE
remove fields from README.md that are now in DKAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,9 @@ Open Data Federal Agency Extras module. Extends DKAN Dataset to include selected
 
  * Bureau Code
  * Program Code
- * Landing Page
- * Data Standard
  * Data Quality
- * Data Dictionary Type
  * Collection
- * Rights
  * Is Part Of
- * Language
  * primary IT Investment UII
  * System of Records
  * Category


### PR DESCRIPTION
The following fields have been added to DKAN without the ODFE module enabled:
* Landing Page (renamed to Homepage URL)
* Data Standard
* Data Dictionary Type
* Rights (renamed to Public Access Level)
* Language